### PR TITLE
add loader-utils as part of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "loader-utils": "^2.0.0",
     "mocha": "^8.2.1"
   },
+  "dependencies": {
+    "loader-utils": "^2.0.0"
+  },
   "peerDependencies": {
     "webpack": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "devDependencies": {
     "eslint": "^7.13.0",
-    "loader-utils": "^2.0.0",
     "mocha": "^8.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
Maybe I've been banging my head against the wall for too long or missing something obvious.

 Yesterday everything worked fine but lately everytime I consume this in a webpack app I see an error that markdown-image-loader cannot resolve `loader-utils`. This kind of makes sense though and not sure how it worked before: if you have something in devDependencies it will only install if you clone the project and locally run `npm i`/`yarn` in the project so when I use this loader and webpack looks in `markdown-image-loader`s node_modules it doesn't have anything. That or I am going crazy and forgot how npm dependencies work

ps sorry for the multiple PRs in less than 24 hours :]